### PR TITLE
docker containerを再作成すると、jupyter labのユーザー設定が消える不具合の修正

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -127,3 +127,8 @@ dmypy.json
 
 # Pyre type checker
 .pyre/
+
+# Kaggle/HousePricesのユーザー設定を除外
+# 例外として、.gitkeepはディレクトリ確保のため除外しない
+/Kaggle/HousePrices/.user-settings/*
+!/Kaggle/HousePrices/.user-settings/.gitkeep

--- a/Kaggle/HousePrices/docker-compose.yml
+++ b/Kaggle/HousePrices/docker-compose.yml
@@ -11,9 +11,12 @@ services:
         # 同じフォルダにあるDockerfileをビルドする。
         build: 
             .
-        # マウントするフォルダを設定。現在のフォルダをDockerコンテナ上の/tmp/workingに紐づける。
+        # マウントするフォルダを設定。
         volumes:
+            # 現在のフォルダをDockerコンテナ上のkaggleフォルダに紐づける。 
             - $PWD:/kaggle
+            # 現在のフォルダ/.user-settingsをコンテナ上のjupyter labのユーザ設定フォルダに紐づける。
+            - $PWD/.user-settings:/home/jovyan/.jupyter/lab/user-settings
         # コンテナ内の初期ディレクトリを設定
         working_dir: 
             /kaggle


### PR DESCRIPTION
ローカルのユーザー設定用のディレクトリとコンテナ側のユーザ設定用ディレクトリを紐づけて、コンテナが削除されてもユーザー設定が消えないようにしています。  
また、余計なユーザー設定がpushされないよう、.gitignoreに除外設定を追加しています。